### PR TITLE
Implement refresh-token based auth API

### DIFF
--- a/src/main/java/com/example/anda_fisher/Config/SecurityConfig.java
+++ b/src/main/java/com/example/anda_fisher/Config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.example.anda_fisher.Config;
 
 import com.example.anda_fisher.Security.JwtAuthenticationFilter;
-import com.example.anda_fisher.Security.JwtService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -25,12 +24,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtService jwtService;
-
-    @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtService);
-    }
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable())
@@ -43,8 +37,7 @@ public class SecurityConfig {
                                 response.sendError(HttpServletResponse.SC_FORBIDDEN, "Forbidden")))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll() // Разрешить доступ
-                        .requestMatchers(HttpMethod.POST, "/auth/login").permitAll()
-                        .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/beaches/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/beaches/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/uploads/images/**").permitAll()
@@ -60,7 +53,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE, "/api/fish/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers("/admin/**").hasAuthority("ROLE_ADMIN")
                         .anyRequest().authenticated())
-                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/example/anda_fisher/Controller/AuthController.java
+++ b/src/main/java/com/example/anda_fisher/Controller/AuthController.java
@@ -1,99 +1,173 @@
 package com.example.anda_fisher.Controller;
 
+import com.example.anda_fisher.DTO.UserDTO;
+import com.example.anda_fisher.DTO.auth.*;
+import com.example.anda_fisher.Mapper.UserMapper;
+import com.example.anda_fisher.Model.RefreshToken;
 import com.example.anda_fisher.Model.User;
 import com.example.anda_fisher.Repository.UserRepository;
 import com.example.anda_fisher.Security.JwtService;
+import com.example.anda_fisher.Service.EmailService;
+import com.example.anda_fisher.Service.PasswordResetService;
+import com.example.anda_fisher.Service.RefreshTokenService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
+
+    private static final String REFRESH_COOKIE_NAME = "refreshToken";
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
+    private final RefreshTokenService refreshTokenService;
+    private final EmailService emailService;
+    private final PasswordResetService passwordResetService;
 
     @PostMapping("/register")
-    public ResponseEntity<String> registerUser(@RequestBody Map<String, String> request) {
-        String username = request.get("username");
-        String password = request.get("password");
-        String email = request.get("email");
-        String phone = request.get("phoneNumber");
+    public ResponseEntity<Map<String, String>> registerUser(@Valid @RequestBody RegisterRequest request) {
+        Map<String, String> response = new HashMap<>();
 
-        if (username == null || password == null || email == null || phone == null) {
-            return new ResponseEntity<>("⚠️ All fields are required!", HttpStatus.BAD_REQUEST);
+        if (userRepository.existsByUsername(request.username())) {
+            response.put("error", "Username already exists");
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
         }
 
-        if (!phone.matches("\\+?[0-9]{9,15}")) {
-            return new ResponseEntity<>("⚠️ Invalid phone number format. It must be 9-15 digits, optionally starting with '+'", HttpStatus.BAD_REQUEST);
+        if (userRepository.existsByEmail(request.email())) {
+            response.put("error", "Email already exists");
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
         }
 
-        if (userRepository.existsByUsername(username)) {
-            return new ResponseEntity<>("⚠️ Username already exists!", HttpStatus.CONFLICT);
-        }
-
-        if (email != null && userRepository.existsByEmail(email)) {
-            return new ResponseEntity<>("⚠️ Email already exists!", HttpStatus.CONFLICT);
-        }
-
-        if (phone != null && userRepository.existsByPhoneNumber(phone)) {
-            return new ResponseEntity<>("⚠️ Phone number already exists!", HttpStatus.CONFLICT);
+        if (request.phoneNumber() != null && !request.phoneNumber().isBlank()
+                && userRepository.existsByPhoneNumber(request.phoneNumber())) {
+            response.put("error", "Phone number already exists");
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
         }
 
         User user = new User();
-        user.setUsername(username);
-        user.setPassword(passwordEncoder.encode(password));
-        user.setEmail(email);
-        user.setPhoneNumber(phone);
+        user.setUsername(request.username());
+        user.setEmail(request.email());
+        user.setPassword(passwordEncoder.encode(request.password()));
+        user.setPhoneNumber(request.phoneNumber());
         user.setActive(true);
 
         userRepository.save(user);
 
-        return new ResponseEntity<>("✅ User registered successfully!", HttpStatus.CREATED);
+        response.put("message", "User registered successfully");
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PostMapping("/login")
-    public ResponseEntity<Map<String, String>> loginUser(@RequestBody Map<String, String> request) {
-        String username = request.get("username");
-        String password = request.get("password");
+    public ResponseEntity<AuthResponse> loginUser(@Valid @RequestBody LoginRequest request) {
+        Optional<User> optionalUser = userRepository.findByUsername(request.username());
 
-        Map<String, String> response = new HashMap<>();
+        if (optionalUser.isEmpty() || !passwordEncoder.matches(request.password(), optionalUser.get().getPassword())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
 
-        if (username == null || username.isBlank() || password == null || password.isBlank()) {
-            response.put("error", "⚠️ Username and password are required!");
-            return ResponseEntity.badRequest().body(response);
+        User user = optionalUser.get();
+        String accessToken = jwtService.generateToken(user.getUsername(), user.getRole());
+        RefreshToken refreshToken = refreshTokenService.create(user);
+
+        return buildAuthResponse(user, accessToken, refreshToken.getToken());
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<AuthResponse> refreshToken(
+            @CookieValue(value = REFRESH_COOKIE_NAME, required = false) String refreshTokenValue) {
+        if (refreshTokenValue == null || refreshTokenValue.isBlank()) {
+            return unauthorizedWithClearedCookie();
         }
 
         try {
-            Optional<User> optionalUser = userRepository.findByUsername(username);
-            if (optionalUser.isEmpty() || !passwordEncoder.matches(password, optionalUser.get().getPassword())) {
-                response.put("error", "❌ Invalid username or password!");
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
-            }
-
-            User user = optionalUser.get();
-
-            String token = jwtService.generateToken(user.getUsername(), user.getRole());
-            response.put("token", token);
-
-            return ResponseEntity.ok(response);
-
-        } catch (Exception e) {
-            response.put("error", "❗ An unexpected error occurred. Please try again later.");
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+            RefreshToken newRefreshToken = refreshTokenService.rotate(refreshTokenValue);
+            User user = newRefreshToken.getUser();
+            String accessToken = jwtService.generateToken(user.getUsername(), user.getRole());
+            return buildAuthResponse(user, accessToken, newRefreshToken.getToken());
+        } catch (IllegalArgumentException ex) {
+            return unauthorizedWithClearedCookie();
         }
     }
 
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @CookieValue(value = REFRESH_COOKIE_NAME, required = false) String refreshTokenValue) {
+        if (refreshTokenValue != null && !refreshTokenValue.isBlank()) {
+            refreshTokenService.revoke(refreshTokenValue);
+        }
+
+        return ResponseEntity.noContent()
+                .header(HttpHeaders.SET_COOKIE, buildExpiredCookie().toString())
+                .build();
+    }
+
+    @PostMapping("/forgot-password")
+    public ResponseEntity<Map<String, String>> forgotPassword(
+            @Valid @RequestBody ForgotPasswordRequest request) {
+        userRepository.findByEmail(request.email()).ifPresent(user -> {
+            String token = passwordResetService.generateTokenFor(user);
+            String message = "Use the following token to reset your password: " + token;
+            emailService.sendSimpleEmail(user.getEmail(), "Password reset", message);
+        });
+
+        return ResponseEntity.ok(Map.of("status", "sent"));
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<Map<String, String>> resetPassword(
+            @Valid @RequestBody ResetPasswordRequest request) {
+        try {
+            passwordResetService.resetPassword(request.token(), request.password());
+            return ResponseEntity.ok(Map.of("status", "updated"));
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("error", ex.getMessage()));
+        }
+    }
+
+    private ResponseEntity<AuthResponse> buildAuthResponse(User user, String accessToken, String refreshTokenValue) {
+        ResponseCookie refreshCookie = ResponseCookie.from(REFRESH_COOKIE_NAME, refreshTokenValue)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Lax")
+                .path("/api/auth")
+                .maxAge(RefreshTokenService.REFRESH_TOKEN_TTL)
+                .build();
+
+        UserDTO userDTO = UserMapper.toDTO(user);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+                .body(new AuthResponse(accessToken, userDTO));
+    }
+
+    private ResponseCookie buildExpiredCookie() {
+        return ResponseCookie.from(REFRESH_COOKIE_NAME, "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Lax")
+                .path("/api/auth")
+                .maxAge(Duration.ZERO)
+                .build();
+    }
+
+    private ResponseEntity<AuthResponse> unauthorizedWithClearedCookie() {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .header(HttpHeaders.SET_COOKIE, buildExpiredCookie().toString())
+                .build();
+    }
 }

--- a/src/main/java/com/example/anda_fisher/DTO/auth/AuthResponse.java
+++ b/src/main/java/com/example/anda_fisher/DTO/auth/AuthResponse.java
@@ -1,0 +1,9 @@
+package com.example.anda_fisher.DTO.auth;
+
+import com.example.anda_fisher.DTO.UserDTO;
+
+public record AuthResponse(
+        String accessToken,
+        UserDTO user
+) {
+}

--- a/src/main/java/com/example/anda_fisher/DTO/auth/ForgotPasswordRequest.java
+++ b/src/main/java/com/example/anda_fisher/DTO/auth/ForgotPasswordRequest.java
@@ -1,0 +1,11 @@
+package com.example.anda_fisher.DTO.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ForgotPasswordRequest(
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email should be valid")
+        String email
+) {
+}

--- a/src/main/java/com/example/anda_fisher/DTO/auth/LoginRequest.java
+++ b/src/main/java/com/example/anda_fisher/DTO/auth/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.example.anda_fisher.DTO.auth;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "Username is required")
+        String username,
+
+        @NotBlank(message = "Password is required")
+        String password
+) {
+}

--- a/src/main/java/com/example/anda_fisher/DTO/auth/RegisterRequest.java
+++ b/src/main/java/com/example/anda_fisher/DTO/auth/RegisterRequest.java
@@ -1,0 +1,27 @@
+package com.example.anda_fisher.DTO.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record RegisterRequest(
+        @NotBlank(message = "Username is required")
+        @Size(min = 3, max = 50, message = "Username must be between 3 and 50 characters")
+        String username,
+
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email should be valid")
+        String email,
+
+        @NotBlank(message = "Password is required")
+        @Size(min = 8, max = 100, message = "Password must be between 8 and 100 characters")
+        String password,
+
+        @Pattern(
+                regexp = "\\+?[0-9\\-\\s\\(\\)]{9,15}",
+                message = "Phone number must be valid and contain 9 to 15 digits, optionally starting with '+'"
+        )
+        String phoneNumber
+) {
+}

--- a/src/main/java/com/example/anda_fisher/DTO/auth/ResetPasswordRequest.java
+++ b/src/main/java/com/example/anda_fisher/DTO/auth/ResetPasswordRequest.java
@@ -1,0 +1,14 @@
+package com.example.anda_fisher.DTO.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ResetPasswordRequest(
+        @NotBlank(message = "Reset token is required")
+        String token,
+
+        @NotBlank(message = "Password is required")
+        @Size(min = 8, max = 100, message = "Password must be between 8 and 100 characters")
+        String password
+) {
+}

--- a/src/main/java/com/example/anda_fisher/Model/PasswordResetToken.java
+++ b/src/main/java/com/example/anda_fisher/Model/PasswordResetToken.java
@@ -1,0 +1,28 @@
+package com.example.anda_fisher.Model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "password_reset_tokens")
+@Getter
+@Setter
+public class PasswordResetToken {
+
+    @Id
+    @Column(length = 64)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(nullable = false)
+    private boolean used = false;
+}

--- a/src/main/java/com/example/anda_fisher/Model/RefreshToken.java
+++ b/src/main/java/com/example/anda_fisher/Model/RefreshToken.java
@@ -1,0 +1,31 @@
+package com.example.anda_fisher.Model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@Setter
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 128)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(nullable = false)
+    private boolean revoked = false;
+}

--- a/src/main/java/com/example/anda_fisher/Repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/example/anda_fisher/Repository/PasswordResetTokenRepository.java
@@ -1,0 +1,11 @@
+package com.example.anda_fisher.Repository;
+
+import com.example.anda_fisher.Model.PasswordResetToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.Instant;
+
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, String> {
+
+    void deleteByExpiresAtBefore(Instant instant);
+}

--- a/src/main/java/com/example/anda_fisher/Repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/anda_fisher/Repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package com.example.anda_fisher.Repository;
+
+import com.example.anda_fisher.Model.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteByExpiresAtBefore(Instant instant);
+}

--- a/src/main/java/com/example/anda_fisher/Repository/UserRepository.java
+++ b/src/main/java/com/example/anda_fisher/Repository/UserRepository.java
@@ -1,7 +1,6 @@
 package com.example.anda_fisher.Repository;
 
 import com.example.anda_fisher.Model.User;
-import jakarta.validation.constraints.Email;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,7 +10,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUsername(String username);
-    Optional<Email> findByEmail(String email);
+    Optional<User> findByEmail(String email);
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);
     boolean existsByPhoneNumber(String phoneNumber);

--- a/src/main/java/com/example/anda_fisher/Security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/anda_fisher/Security/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -20,6 +21,8 @@ import java.util.Collections;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+    private static final String AUTH_WHITELIST_PREFIX = "/api/auth";
+
     private final JwtService jwtService;
 
     @Override
@@ -27,15 +30,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
-        String authHeader = request.getHeader("Authorization");
-
-        if (request.getServletPath().equals("/auth/login")) {
+        String path = request.getServletPath();
+        if (path.startsWith(AUTH_WHITELIST_PREFIX)) {
             filterChain.doFilter(request, response);
             return;
         }
 
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            logger.warn("🚫 No JWT token found in request headers");
             filterChain.doFilter(request, response);
             return;
         }
@@ -43,7 +46,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = authHeader.substring(7);
 
         if (!jwtService.validateToken(token)) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid Token");
+            logger.warn("Invalid JWT token provided");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token");
             return;
         }
 
@@ -53,8 +57,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         UsernamePasswordAuthenticationToken authenticationToken =
                 new UsernamePasswordAuthenticationToken(username, null, Collections.singleton(() -> role));
 
-
         SecurityContextHolder.getContext().setAuthentication(authenticationToken);
         filterChain.doFilter(request, response);
-        }
     }
+}

--- a/src/main/java/com/example/anda_fisher/Security/JwtService.java
+++ b/src/main/java/com/example/anda_fisher/Security/JwtService.java
@@ -22,8 +22,8 @@ public class JwtService {
                       @Value("${jwt.expirationMs}") long expirationTimeMs) {
         this.jwtSecret = jwtSecret;
         this.expirationTimeMs = expirationTimeMs;
-        validateSecretKey();    }
-
+        validateSecretKey();
+    }
 
     @PostConstruct
     private void validateSecretKey() {

--- a/src/main/java/com/example/anda_fisher/Service/PasswordResetService.java
+++ b/src/main/java/com/example/anda_fisher/Service/PasswordResetService.java
@@ -1,0 +1,55 @@
+package com.example.anda_fisher.Service;
+
+import com.example.anda_fisher.Model.PasswordResetToken;
+import com.example.anda_fisher.Model.User;
+import com.example.anda_fisher.Repository.PasswordResetTokenRepository;
+import com.example.anda_fisher.Repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordResetService {
+
+    private static final Duration PASSWORD_RESET_TTL = Duration.ofHours(1);
+
+    private final PasswordResetTokenRepository passwordResetTokenRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public String generateTokenFor(User user) {
+        passwordResetTokenRepository.deleteByExpiresAtBefore(Instant.now());
+
+        PasswordResetToken token = new PasswordResetToken();
+        token.setToken(UUID.randomUUID().toString());
+        token.setUser(user);
+        token.setExpiresAt(Instant.now().plus(PASSWORD_RESET_TTL));
+        token.setUsed(false);
+        passwordResetTokenRepository.save(token);
+        return token.getToken();
+    }
+
+    @Transactional
+    public void resetPassword(String tokenValue, String newPassword) {
+        PasswordResetToken token = passwordResetTokenRepository.findById(tokenValue)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid reset token"));
+
+        if (token.isUsed() || token.getExpiresAt().isBefore(Instant.now())) {
+            throw new IllegalArgumentException("Expired or used reset token");
+        }
+
+        User user = token.getUser();
+        user.setPassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+
+        token.setUsed(true);
+        passwordResetTokenRepository.save(token);
+    }
+}

--- a/src/main/java/com/example/anda_fisher/Service/RefreshTokenService.java
+++ b/src/main/java/com/example/anda_fisher/Service/RefreshTokenService.java
@@ -1,0 +1,58 @@
+package com.example.anda_fisher.Service;
+
+import com.example.anda_fisher.Model.RefreshToken;
+import com.example.anda_fisher.Model.User;
+import com.example.anda_fisher.Repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    public static final Duration REFRESH_TOKEN_TTL = Duration.ofDays(14);
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public RefreshToken create(User user) {
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken(UUID.randomUUID().toString());
+        refreshToken.setUser(user);
+        refreshToken.setExpiresAt(Instant.now().plus(REFRESH_TOKEN_TTL));
+        refreshToken.setRevoked(false);
+        return refreshTokenRepository.save(refreshToken);
+    }
+
+    @Transactional
+    public RefreshToken rotate(String tokenValue) {
+        RefreshToken existing = getValidToken(tokenValue);
+        existing.setRevoked(true);
+        refreshTokenRepository.save(existing);
+        return create(existing.getUser());
+    }
+
+    @Transactional
+    public void revoke(String tokenValue) {
+        refreshTokenRepository.findByToken(tokenValue).ifPresent(token -> {
+            token.setRevoked(true);
+            refreshTokenRepository.save(token);
+        });
+    }
+
+    public RefreshToken getValidToken(String tokenValue) {
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(tokenValue)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid refresh token"));
+
+        if (refreshToken.isRevoked() || refreshToken.getExpiresAt().isBefore(Instant.now())) {
+            throw new IllegalArgumentException("Expired or revoked refresh token");
+        }
+
+        return refreshToken;
+    }
+}


### PR DESCRIPTION
## Summary
- refactor the authentication controller under /api/auth with DTO-backed register, login, refresh, logout, forgot-password and reset-password endpoints
- add refresh token persistence, rotation service and HttpOnly cookie handling along with password reset token service and email dispatch
- update security configuration and JWT filter to permit the new routes and ignore auth paths when validating bearer tokens

## Testing
- `./mvnw -q -DskipTests package` *(fails: Maven wrapper could not download dependencies because the network is unreachable)*
- `mvn -q -DskipTests package` *(fails: Maven cannot resolve the Spring Boot parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cad8de99e083218caacc3523dd19e2