### PR TITLE
Use email for authentication and add repository tests

### DIFF
--- a/src/main/java/com/example/anda_fisher/Controller/AuthController.java
+++ b/src/main/java/com/example/anda_fisher/Controller/AuthController.java
@@ -73,7 +73,7 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<AuthResponse> loginUser(@Valid @RequestBody LoginRequest request) {
-        Optional<User> optionalUser = userRepository.findByUsername(request.username());
+        Optional<User> optionalUser = userRepository.findByEmail(request.email());
 
         if (optionalUser.isEmpty() || !passwordEncoder.matches(request.password(), optionalUser.get().getPassword())) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();

--- a/src/main/java/com/example/anda_fisher/DTO/auth/LoginRequest.java
+++ b/src/main/java/com/example/anda_fisher/DTO/auth/LoginRequest.java
@@ -1,10 +1,12 @@
 package com.example.anda_fisher.DTO.auth;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record LoginRequest(
-        @NotBlank(message = "Username is required")
-        String username,
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email should be valid")
+        String email,
 
         @NotBlank(message = "Password is required")
         String password

--- a/src/main/java/com/example/anda_fisher/Service/UserService.java
+++ b/src/main/java/com/example/anda_fisher/Service/UserService.java
@@ -31,13 +31,13 @@ public class UserService {
         return userRepository.save(user);
     }
 
-    public User findByUsername(String username) {
-        return userRepository.findByUsername(username)
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("User not found"));
     }
 
-    public User authenticateUser(String username, String rawPassword) {
-        User user = findByUsername(username);
+    public User authenticateUser(String email, String rawPassword) {
+        User user = findByEmail(email);
         if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
             throw new RuntimeException("Invalid password");
         }

--- a/src/test/java/com/example/anda_fisher/Repository/UserRepositoryTest.java
+++ b/src/test/java/com/example/anda_fisher/Repository/UserRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.example.anda_fisher.Repository;
+
+import com.example.anda_fisher.Model.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("findByEmail returns user when email exists")
+    void findByEmailReturnsUserWhenEmailExists() {
+        User user = new User();
+        user.setUsername("test_user");
+        user.setEmail("test@example.com");
+        user.setPassword("password123");
+        userRepository.save(user);
+
+        Optional<User> result = userRepository.findByEmail("test@example.com");
+
+        assertThat(result)
+                .as("Expected to find user by email")
+                .isPresent();
+
+        User foundUser = result.orElseThrow();
+        assertThat(foundUser.getEmail()).isEqualTo("test@example.com");
+        assertThat(foundUser.getUsername()).isEqualTo("test_user");
+    }
+
+    @Test
+    @DisplayName("findByEmail returns empty when email does not exist")
+    void findByEmailReturnsEmptyWhenEmailDoesNotExist() {
+        Optional<User> result = userRepository.findByEmail("absent@example.com");
+
+        assertThat(result)
+                .as("Expected no user to be found for non-existing email")
+                .isNotPresent();
+    }
+}


### PR DESCRIPTION
## Summary
- update the authentication flow to locate users by email and validate the login request payload
- adjust the user service to authenticate via email lookups
- add repository tests that cover existing and missing email queries

## Testing
- mvn test *(fails: dependency download blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cadce512288321a3fcb6367c7a886a