### PR TITLE
Expose health actuator endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,17 +140,23 @@
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 
-		<!-- Spring Boot Starter Web: Spring MVC -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <!-- Spring Boot Starter Web: Spring MVC -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
 
-		<!-- Spring Boot Starter Security: authentication and authorization -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
+                <!-- Spring Boot Actuator: production-ready features -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-actuator</artifactId>
+                </dependency>
+
+                <!-- Spring Boot Starter Security: authentication and authorization -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-security</artifactId>
+                </dependency>
 
 		<!-- PostgreSQL Driver -->
 		<dependency>

--- a/src/main/java/com/example/anda_fisher/Config/SecurityConfig.java
+++ b/src/main/java/com/example/anda_fisher/Config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                                 response.sendError(HttpServletResponse.SC_FORBIDDEN, "Forbidden")))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll() // Разрешить доступ
+                        .requestMatchers(HttpMethod.GET, "/actuator/health").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/beaches/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/beaches/**").permitAll()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,3 +31,5 @@ spring.mail.properties.mail.smtp.starttls.required=${SPRING_MAIL_SMTP_STARTTLS_R
 spring.mail.properties.mail.debug=${SPRING_MAIL_DEBUG:false}
 
 springdoc.swagger-ui.enabled=${SPRINGDOC_SWAGGER_UI_ENABLED:true}
+
+management.endpoints.web.exposure.include=health

--- a/src/test/java/com/example/anda_fisher/ActuatorHealthEndpointTest.java
+++ b/src/test/java/com/example/anda_fisher/ActuatorHealthEndpointTest.java
@@ -1,0 +1,29 @@
+package com.example.anda_fisher;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+        "jwt.secret=abcdefghijklmnopqrstuvwxyz123456",
+        "jwt.expirationMs=3600000"
+})
+@AutoConfigureMockMvc
+class ActuatorHealthEndpointTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void healthEndpointReturnsUp() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"));
+    }
+}


### PR DESCRIPTION
## Summary
- add the Spring Boot Actuator starter to enable management endpoints
- expose the health endpoint via application properties and security configuration
- add a MockMvc test verifying that the health endpoint reports an UP status

## Testing
- mvn test *(fails: network is unreachable when resolving Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cadde4f7288321a3d6a3fd9d6bf186