### PR TITLE
Add missing repository query methods for token operations

### DIFF
--- a/src/main/java/com/example/anda_fisher/Repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/example/anda_fisher/Repository/PasswordResetTokenRepository.java
@@ -1,12 +1,19 @@
 package com.example.anda_fisher.Repository;
 
 import com.example.anda_fisher.Model.PasswordResetToken;
+import com.example.anda_fisher.Model.User;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, String> {
+
+    List<PasswordResetToken> findAllByUserAndUsedFalse(User user);
+
+    Optional<PasswordResetToken> findByToken(String token);
 
     void deleteByExpiresAtBefore(Instant instant);
 

--- a/src/main/java/com/example/anda_fisher/Repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/anda_fisher/Repository/RefreshTokenRepository.java
@@ -5,12 +5,16 @@ import com.example.anda_fisher.Model.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
+
+import com.example.anda_fisher.Model.User;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByToken(String token);
 
+    List<RefreshToken> findAllByUserAndRevokedFalse(User user);
 
     void deleteByExpiresAtBefore(Instant instant);
 }


### PR DESCRIPTION
### Motivation
- Fix compilation errors in `TokenService` where derived Spring Data JPA query methods were not found for token-related operations.
- Ensure repository interfaces expose queries used to revoke/lookup `RefreshToken` and `PasswordResetToken` instances.

### Description
- Added `List<RefreshToken> findAllByUserAndRevokedFalse(User user)` to `RefreshTokenRepository`.
- Added `List<PasswordResetToken> findAllByUserAndUsedFalse(User user)` and `Optional<PasswordResetToken> findByToken(String token)` to `PasswordResetTokenRepository`.
- Added necessary imports for `User`, `List`, and `Optional` in the updated repository files.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69669a5733748321837e1b86c7559fef)